### PR TITLE
Sammelepisode für März 2024

### DIFF
--- a/2024 März/Sammlung.txt
+++ b/2024 März/Sammlung.txt
@@ -1,0 +1,4 @@
+- Elon verklagt OpenAi
+  - OpenAI hat ne total komplizierte Firmenstruktur
+  - OpenAI reagiert öffentlich, zeigt Mails von früher
+- OpenAi zeigt Sora (oder war das Februar?)


### PR DESCRIPTION
Lass uns hier mal alles für März sammeln, wie es reinkommt – dann haben wir Anfang April wenig Aufwand für die Rückblick-/Sammelepisode